### PR TITLE
added double inclusion failsafe for template.h

### DIFF
--- a/C/template.h
+++ b/C/template.h
@@ -1,3 +1,8 @@
+#ifndef TEMPLATE_H
+#define TEMPLATE_H
+// add definitions after this line
+
+
 // necessary libraries / header-files
 #include "stdio.h"
 #include "stdlib.h"
@@ -134,3 +139,8 @@ typedef signed long long int llint;    // %lld
 typedef unsigned long long int ullint; // %llu
 // ... double
 typedef long double ldouble; // %Lf
+
+
+
+// add definitions before this line
+#endif


### PR DESCRIPTION
### Problematic Cases
#### case 1
Lets say that we included **template.h** twice in a file:
```c
/*main.c*/

#include "template.h"
#include "template.h"

start_
    print_("hello");
    Exit
```
#### case 2
or, included a file where **template.h** in already used
```c
/*my_lib.c*/

#include "template.h"

int greet() {
    print("hello");
}
```
```c
/*main.c*/

#include "template.h"
#include "my_lib.c"

start_
    greet();
    Exit

```

### Case Synopsis and Implemented Fix
in both cases the **template.h** is included more than once
to fix this issue we did the following where _TEMPLATE_H_ is a pseudo definition:

1. An _#ifndef_  block was added to check the definition of _TEMPLATE_H_
2. if not defined a pseudo variable _TEMPLATE_H_ gets defined
3. Previous definitions was moved into the block to have conditional inclusion
4. Any following inclusion of "template.h" will result the if block to not include the macro definitions

Hence this fix will mitigate the aftereffects of a multiple inclusion scenario.